### PR TITLE
Vertically centre h1 button text

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,12 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
     <!-- Optional theme -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap-theme.min.css" integrity="sha384-fLW2N01lMqjakBkx3l/M9EahuwpSfeNvV63J5ezn3uZzapT0u7EYsXMjQV+0En5r" crossorigin="anonymous">
+    <style>
+      button h1 {
+        margin-top: 15px;
+        margin-bottom: 15px;
+      }
+    </style>
 
     <!-- <link rel="stylesheet" href="custom.css"> -->
     <!-- FOR LOCAL TESTING: -->


### PR DESCRIPTION
Fixes #4.

Overrides bootstrap.css:

``` css
.h1, .h2, .h3, h1, h2, h3 {
    margin-top: 20px;
    margin-bottom: 10px;
}
```

Demo: https://hugovk.github.io/PomPom/

Before:
![image](https://cloud.githubusercontent.com/assets/1324225/19019912/bff166d6-88a0-11e6-92fc-f3e26ba5a7b2.png)

After: 
![image](https://cloud.githubusercontent.com/assets/1324225/19019911/ae27e308-88a0-11e6-96cd-6b8fe4b1ee5d.png)

Would you prefer it in a separate CSS file?
